### PR TITLE
Cadastro dos candidatos atualizado

### DIFF
--- a/public/js/candidatos/selecionar-areas.js
+++ b/public/js/candidatos/selecionar-areas.js
@@ -1,29 +1,36 @@
-  const botoes = document.querySelectorAll('.area-btn');
-    const campoHidden = document.getElementById('areasSelecionadas');
+document.addEventListener('DOMContentLoaded', () => {
+  const botoes      = document.querySelectorAll('.area-btn');
+  const campoHidden = document.getElementById('areasSelecionadas');
+  const form        = document.getElementById('formAreas');
+  let selecionadas  = [];
 
-    let selecionadas = [];
+  botoes.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const valor = btn.dataset.value;
 
-    botoes.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const valor = btn.dataset.value;
-
-        if (selecionadas.includes(valor)) {
-          selecionadas = selecionadas.filter(v => v !== valor);
-          btn.classList.remove('selected');
+      if (selecionadas.includes(valor)) {
+        // desmarcar
+        selecionadas = selecionadas.filter(v => v !== valor);
+        btn.classList.remove('selected');
+      } else {
+        if (selecionadas.length < 3) {
+          // marcar
+          selecionadas.push(valor);
+          btn.classList.add('selected');
         } else {
-          if (selecionadas.length < 3) {
-            selecionadas.push(valor);
-            btn.classList.add('selected');
-          }
+          alert('Você só pode selecionar até 3 áreas.');
         }
-
-        campoHidden.value = selecionadas.join(',');
-      });
-    });
-
-    document.getElementById('formAreas').addEventListener('submit', function (e) {
-      if (selecionadas.length !== 3) {
-        e.preventDefault();
-        alert('Por favor, selecione exatamente 3 áreas de interesse.');
       }
+
+      // atualiza o campo oculto
+      campoHidden.value = selecionadas.join(',');
     });
+  });
+
+  form.addEventListener('submit', e => {
+    if (selecionadas.length !== 3) {
+      e.preventDefault();
+      alert('Por favor, selecione exatamente 3 áreas de interesse.');
+    }
+  });
+});

--- a/public/js/shared/botoesFotosEditarPerfil.js
+++ b/public/js/shared/botoesFotosEditarPerfil.js
@@ -1,4 +1,76 @@
-    document.getElementById('btnAlterarFoto').addEventListener('click', function () {
-      document.getElementById('btnAlterarFoto').classList.add('d-none');
-      document.getElementById('botoesFoto').classList.remove('d-none');
-    });
+// public/js/shared/botoesFotosEditar-perfil-empresa.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btnAlterar     = document.getElementById('btnAlterarFoto');
+  const botoesFoto     = document.getElementById('botoesFoto');
+  const cameraContainer= document.getElementById('cameraContainer');
+  const video          = document.getElementById('camera');
+  const canvas         = document.getElementById('canvas');
+  const fotoFileInput  = document.getElementById('fotoArquivo');
+  const hiddenBase64   = document.getElementById('fotoBase64');
+  const preview        = document.getElementById('previewImagem');
+  let stream            = null;
+
+  // mostra os botões de escolha
+  btnAlterar.addEventListener('click', () => {
+    btnAlterar.classList.add('d-none');
+    botoesFoto.classList.remove('d-none');
+  });
+
+  // expõe no escopo global para poder chamar do onclick
+  window.abrirCamera = () => {
+    botoesFoto.classList.add('d-none');
+    cameraContainer.classList.remove('d-none');
+
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(s => {
+        stream = s;
+        video.srcObject = s;
+      })
+      .catch(err => {
+        alert('Não foi possível acessar a câmera: ' + err);
+      });
+  };
+
+  window.capturarFoto = () => {
+    const w = video.videoWidth;
+    const h = video.videoHeight;
+    canvas.width = w;
+    canvas.height = h;
+    canvas.getContext('2d').drawImage(video, 0, 0, w, h);
+
+    canvas.toBlob(blob => {
+      // 1) popula o input type=file para o multer captar
+      const file = new File([blob], `camera_${Date.now()}.png`, { type: 'image/png' });
+      const dt   = new DataTransfer();
+      dt.items.add(file);
+      fotoFileInput.files = dt.files;
+
+      // 2) atualiza o campo hidden com base64 e o preview
+      const reader = new FileReader();
+      reader.onload = e => {
+        hiddenBase64.value = e.target.result;
+        preview.src       = e.target.result;
+      };
+      reader.readAsDataURL(file);
+
+      // 3) para a câmera
+      stream.getTracks().forEach(t => t.stop());
+      video.srcObject = null;
+      cameraContainer.classList.add('d-none');
+    }, 'image/png');
+  };
+
+  // preview quando seleciona do dispositivo
+  fotoFileInput.addEventListener('change', () => {
+    const file = fotoFileInput.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = e => {
+      hiddenBase64.value = e.target.result;
+      preview.src       = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  });
+});

--- a/public/js/shared/fotoPerfil.js
+++ b/public/js/shared/fotoPerfil.js
@@ -1,89 +1,97 @@
-const tirarFotoBtn = document.getElementById('tirarFotoBtn');
-const outraFotoBtn = document.getElementById('outraFoto');
-const video = document.getElementById('video');
-const canvas = document.getElementById('canvas');
-const preview = document.getElementById('previewFoto');
-const uploadInput = document.getElementById('upload');
-const opcoesFoto = document.getElementById('opcoesFoto');
-const acoesFoto = document.getElementById('acoesFoto');
-const form = document.getElementById('formFoto');
-const erroFoto = document.getElementById('erroFoto');
+// fotoPerfil.js
+
+// Elementos do DOM
+const tirarFotoBtn  = document.getElementById('tirarFotoBtn');
+const outraFotoBtn  = document.getElementById('outraFoto');
+const video         = document.getElementById('video');
+const canvas        = document.getElementById('canvas');
+const preview       = document.getElementById('previewFoto');
+const uploadInput   = document.getElementById('novaFoto');
+const opcoesFoto    = document.getElementById('opcoesFoto');
+const acoesFoto     = document.getElementById('acoesFoto');
+const form          = document.getElementById('formFoto');
+const erroFoto      = document.getElementById('erroFoto');
 
 let cameraAtiva = false;
 
-if (tirarFotoBtn) {
-  tirarFotoBtn.addEventListener('click', () => {
-    if (!cameraAtiva) {
-      navigator.mediaDevices.getUserMedia({ video: true })
-        .then(stream => {
-          video.srcObject = stream;
-          video.style.display = 'block';
-          cameraAtiva = true;
-        })
-        .catch(err => alert('Erro ao acessar a câmera: ' + err));
-    } else {
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-
-      canvas.toBlob(blob => {
-        const file = new File([blob], `camera-foto-${Date.now()}.png`, { type: 'image/png' });
-        const dataTransfer = new DataTransfer();
-        dataTransfer.items.add(file);
-        uploadInput.files = dataTransfer.files;
-
-        const reader = new FileReader();
-        reader.onload = e => {
-          preview.src = e.target.result;
-          preview.style.display = 'block';
-
-          document.getElementById('fotoBase64').value = base64;
-        };
-        reader.readAsDataURL(file);
-      });
-
-      video.srcObject.getTracks().forEach(track => track.stop());
-      video.style.display = 'none';
-      opcoesFoto.style.display = 'none';
-      acoesFoto.style.display = 'flex';
-      cameraAtiva = false;
-    }
-  });
-}
-
-uploadInput?.addEventListener('change', () => {
-  const file = uploadInput.files[0];
-  if (file) {
-    const reader = new FileReader();
-    reader.onload = function (e) {
-      preview.src = e.target.result;
-      preview.style.display = 'block';
-      opcoesFoto.style.display = 'none';
-      acoesFoto.style.display = 'flex';
-    };
-    reader.readAsDataURL(file);
-  }
-});
-
-outraFotoBtn?.addEventListener('click', () => {
-  preview.style.display = 'none';
+// Função para resetar a prévia ao avatar padrão
+function resetPreview() {
+  preview.src = '/img/avatar.png';
+  preview.style.display = 'block';
+  uploadInput.value = '';
+  // Esconde ações e mostra opções de novo
   acoesFoto.style.display = 'none';
   opcoesFoto.style.display = 'flex';
-  uploadInput.value = '';
+  erroFoto.style.display = 'none';
+}
+
+// Quando clicar em “Fazer upload”
+uploadInput?.addEventListener('change', () => {
+  const file = uploadInput.files[0];
+  if (!file) return resetPreview();
+
+  const reader = new FileReader();
+  reader.onload = e => {
+    preview.src = e.target.result;
+    preview.style.display = 'block';
+    opcoesFoto.style.display = 'none';
+    acoesFoto.style.display = 'flex';
+  };
+  reader.readAsDataURL(file);
 });
 
-form?.addEventListener('submit', function (e) {
-  if (uploadInput.files.length === 0) {
+// Quando clicar em “Capturar agora”
+tirarFotoBtn?.addEventListener('click', () => {
+  if (!cameraAtiva) {
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(stream => {
+        video.srcObject = stream;
+        video.style.display = 'block';
+        opcoesFoto.style.display = 'none';
+        cameraAtiva = true;
+      })
+      .catch(err => alert('Erro ao acessar a câmera: ' + err));
+  } else {
+    // Tira a foto
+    canvas.width  = video.videoWidth;
+    canvas.height = video.videoHeight;
+    canvas.getContext('2d').drawImage(video, 0, 0);
+
+    canvas.toBlob(blob => {
+      const file = new File([blob], `camera-${Date.now()}.png`, { type: 'image/png' });
+      const dt   = new DataTransfer();
+      dt.items.add(file);
+      uploadInput.files = dt.files;
+
+      // Atualiza preview
+      const reader = new FileReader();
+      reader.onload = e => {
+        preview.src = e.target.result;
+        preview.style.display = 'block';
+        acoesFoto.style.display = 'flex';
+      };
+      reader.readAsDataURL(file);
+    }, 'image/png');
+
+    // Para a câmera
+    video.srcObject.getTracks().forEach(t => t.stop());
+    video.style.display = 'none';
+    cameraAtiva = false;
+  }
+});
+
+// “Tirar outra”
+outraFotoBtn?.addEventListener('click', resetPreview);
+
+// Valida antes de enviar
+form?.addEventListener('submit', e => {
+  if (!uploadInput.files.length) {
     e.preventDefault();
     erroFoto.style.display = 'block';
-  } else {
-    erroFoto.style.display = 'none';
   }
 });
 
+// Ao carregar a página, garante que o avatar apareça
 window.addEventListener('DOMContentLoaded', () => {
-  if (preview && !preview.src.includes('blob') && !uploadInput.value) {
-    preview.style.display = 'block'; // mostra o avatar.png inicial
-  }
+  resetPreview();
 });

--- a/scripts/deleteUsuario.js
+++ b/scripts/deleteUsuario.js
@@ -69,4 +69,4 @@ async function deletarContaPorEmail(email) {
 }
 
 // Troque aqui pelo e-mail desejado
-deletarContaPorEmail('brunowaschburgers@gmail.com');
+deletarContaPorEmail('tg049932@gmail.com');

--- a/src/config/cloudinary.js
+++ b/src/config/cloudinary.js
@@ -1,19 +1,9 @@
-const cloudinary = require("cloudinary").v2;
-const { CloudinaryStorage } = require("multer-storage-cloudinary");
+const cloudinary = require('cloudinary').v2;
 
 cloudinary.config({
-  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
-  api_key: process.env.CLOUDINARY_API_KEY,
-  api_secret: process.env.CLOUDINARY_API_SECRET
+  cloud_name:   process.env.CLOUDINARY_CLOUD_NAME,
+  api_key:      process.env.CLOUDINARY_API_KEY,
+  api_secret:   process.env.CLOUDINARY_API_SECRET,
 });
 
-const storage = new CloudinaryStorage({
-  cloudinary,
-  params: {
-    folder: 'connect-skills',
-    allowed_formats: ['jpg', 'jpeg', 'png'],
-    transformation: [{ width: 500, height: 500, crop: "limit" }],
-  },
-});
-
-module.exports = { cloudinary, storage };
+module.exports = cloudinary;

--- a/src/middlewares/upload.js
+++ b/src/middlewares/upload.js
@@ -1,6 +1,15 @@
+// middlewares/upload.js
 const multer = require('multer');
-const { storage } = require('../config/cloudinary'); 
 
-const upload = multer({ storage });
+// Armazenamento em memória para pegar o buffer diretamente
+const storage = multer.memoryStorage();
 
-module.exports = upload;
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 } // até 5 MB
+});
+
+module.exports = multer({
+  storage: multer.memoryStorage(),
+  limits:  { fileSize: 5 * 1024 * 1024 }
+});

--- a/src/routes/candidatoRoutes.js
+++ b/src/routes/candidatoRoutes.js
@@ -1,34 +1,37 @@
-const express = require('express');
-const router = express.Router();
-const candidatoController = require('../controllers/candidatoController');
-const upload = require('../middlewares/upload');
-const { ensureCandidato } = require('../middlewares/auth');
-const { renderMeuPerfil } = require('../controllers/candidatoController');
-const { storage } = require('../config/cloudinary');
-const multer = require('multer');
+// routes/candidato.js
+const express               = require('express');
+const router                = express.Router();
+const candidatoController   = require('../controllers/candidatoController');
+const upload                = require('../middlewares/upload');
+const { ensureCandidato }    = require('../middlewares/auth');
 
+// Fluxo de cadastro
 router.get('/cadastro/nome', candidatoController.telaNomeCandidato);
 router.post('/cadastro/nome', candidatoController.salvarNomeCandidato);
 
-router.get('/cadastro/localizacao', candidatoController.telaLocalizacao);
-router.post('/cadastro/localizacao', candidatoController.salvarLocalizacao);
+router.get('/localizacao', candidatoController.telaLocalizacao);
+router.post('/localizacao', candidatoController.salvarLocalizacao);
 
-router.get('/cadastro/telefone', candidatoController.telaTelefone);
-router.post('/cadastro/telefone', candidatoController.salvarTelefone);
+router.get('/telefone', candidatoController.telaTelefone);
+router.post('/telefone', candidatoController.salvarTelefone);
 
 router.get('/cadastro/foto-perfil', candidatoController.telaFotoPerfil);
-router.post('/candidato/foto-perfil', upload.single('novaFoto'), candidatoController.salvarFotoPerfil);
+router.post(
+  '/cadastro/foto-perfil',
+  upload.single('novaFoto'),
+  candidatoController.salvarFotoPerfil
+);
 
 router.get('/cadastro/areas', candidatoController.telaSelecionarAreas);
-router.post('/cadastro/areas', candidatoController.salvarAreas);    
+router.post('/cadastro/areas', candidatoController.salvarAreas);
 
-// Acesso autenticado
-router.get('/home', ensureCandidato, candidatoController.telaHomeCandidato); 
+// Rotas autenticadas
+router.get('/home', ensureCandidato, candidatoController.telaHomeCandidato);
 router.get('/meu-perfil', ensureCandidato, candidatoController.renderMeuPerfil);
 router.get('/vagas', ensureCandidato, candidatoController.mostrarVagas);
 
-// Edição de perfil do candidato
-router.get('/editar-perfil',  ensureCandidato, candidatoController.telaEditarPerfil, candidatoController.mostrarPerfil);
-router.post('/editar-perfil', ensureCandidato, upload.single('novaFoto'), candidatoController.salvarEditarPerfil);
+// Edição de perfil
+router.get('/editar-perfil', ensureCandidato, candidatoController.telaEditarPerfil);
+router.post( '/editar-perfil', ensureCandidato, upload.single('novaFoto'), candidatoController.salvarEditarPerfil);
 
 module.exports = router;

--- a/src/views/candidatos/foto-perfil.ejs
+++ b/src/views/candidatos/foto-perfil.ejs
@@ -4,8 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Foto de Perfil - Connect Skills</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+  >
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+  >
   <link rel="stylesheet" href="/css/shared/style.css">
   <link rel="stylesheet" href="/css/shared/fotoPerfil.css">
   <link rel="icon" href="/img/CONNECT.png">
@@ -13,41 +19,89 @@
 <body>
   <%- include('../partials/header') %>
 
-  <main class="main-ajustado-header d-flex flex-column align-items-center justify-content-center px-3 text-center">
+  <main
+    class="main-ajustado-header d-flex flex-column align-items-center justify-content-center px-3 text-center"
+  >
     <h3 class="text-center mt-4 mb-3">Adicione uma foto de perfil</h3>
 
-    <form action="/candidato/foto-perfil" method="POST" enctype="multipart/form-data" id="formFoto" class="text-center">
-      <input type="hidden" name="usuario_id" value="<%= usuario_id %>">
+    <form
+      action="/candidato/cadastro/foto-perfil?usuario_id=<%= usuarioId %>"
+      method="POST"
+      enctype="multipart/form-data"
+      id="formFoto"
+      class="text-center"
+    >
+      <input type="hidden" name="usuario_id" value="<%= usuarioId %>">
+
+      <% if (error) { %>
+        <div class="alert alert-danger w-100 mb-3"><%= error %></div>
+      <% } %>
 
       <!-- Prévia da foto -->
-      <img src="/img/avatar.png" alt="Prévia da Foto" id="previewFoto" class="foto-icon mb-3" width="150" height="150">
+      <img
+        src="/img/avatar.png"
+        alt="Prévia da Foto"
+        id="previewFoto"
+        class="foto-icon mb-3"
+        width="150"
+        height="150"
+      >
 
-      <!-- Opções -->
-      <div class="d-flex gap-4 flex-wrap justify-content-center botoes-container" id="opcoesFoto">
-        <label class="upload-btn" for="upload">
+      <!-- Opções iniciais: upload ou câmera -->
+      <div
+        id="opcoesFoto"
+        class="d-flex gap-4 flex-wrap justify-content-center mb-3"
+      >
+        <label class="upload-btn" for="novaFoto">
           📤 Fazer upload
         </label>
-        <input type="file" name="fotoUpload" id="upload" accept="image/*" class="hidden-input" required>
+        <input
+          type="file"
+          name="novaFoto"
+          id="novaFoto"
+          accept="image/*"
+          class="hidden-input"
+        >
 
-        <button type="button" class="upload-btn" id="tirarFotoBtn">
+        <button
+          type="button"
+          class="upload-btn"
+          id="tirarFotoBtn"
+        >
           📸 Capturar agora
         </button>
       </div>
 
-      <!-- Vídeo e canvas ocultos -->
+      <!-- Vídeo e canvas, só aparecem durante captura -->
       <video id="video" autoplay playsinline style="display: none;"></video>
       <canvas id="canvas" style="display: none;"></canvas>
 
-      <p id="erroFoto" class="text-danger fw-semibold mt-2" style="display: none;">
+      <!-- Mensagem de erro de foto -->
+      <p
+        id="erroFoto"
+        class="text-danger fw-semibold mt-2"
+        style="display: none;"
+      >
         Por favor, selecione ou tire uma foto antes de continuar.
       </p>
 
-      <!-- Botões após foto -->
-      <div id="acoesFoto" class="acoesFoto flex-wrap justify-content-center gap-3 mt-4" style="display: none;">
-        <button type="button" class="btn-acao btn-cancelar" id="outraFoto">
+      <!-- Ações após foto: confirmar/continuar ou trocar -->
+      <div
+        id="acoesFoto"
+        class="acoesFoto flex-wrap justify-content-center gap-3 mt-4"
+        style="display: none;"
+      >
+        <button
+          type="button"
+          class="btn-acao btn-cancelar"
+          id="outraFoto"
+        >
           <i class="bi bi-arrow-clockwise me-1"></i> Tirar outra
         </button>
-        <button type="submit" class="btn-acao btn-confirmar">
+        <button
+          type="submit"
+          class="btn-acao btn-confirmar"
+        >
           <i class="bi bi-check-circle me-1"></i> Confirmar e continuar
         </button>
       </div>

--- a/src/views/candidatos/selecionar-areas.ejs
+++ b/src/views/candidatos/selecionar-areas.ejs
@@ -16,7 +16,7 @@
 <main class="container text-center mt-5 pt-5">
 
     <h2 class="mb-4">Selecione a seguir três áreas a quais você deseja trabalhar:</h5>
-    <form action="/candidato/areas" method="POST" id="formAreas">
+    <form action="/candidato/cadastro/areas?usuario_id=<%= usuario_id %>" method="POST" id="formAreas">
       <input type="hidden" name="usuario_id" value="<%= usuario_id %>">
       <div id="botoes" class="d-flex flex-wrap justify-content-center">
         <% const opcoes = [

--- a/src/views/candidatos/telefone.ejs
+++ b/src/views/candidatos/telefone.ejs
@@ -19,10 +19,14 @@
     <form action="/candidato/telefone" method="POST" id="formTelefone" novalidate>
 
       <!-- Campo oculto com ID do usuário -->
-      <input type="hidden" name="usuario_id" value="<%= usuario_id %>">
+      <input type="hidden" name="usuario_id" value="<%= usuarioId %>">
 
       <!-- Campo oculto com DDI fixo -->
       <input type="hidden" name="ddi" value="+55">
+
+      <% if (error) { %>
+        <div class="alert alert-danger text-center"><%= error %></div>
+      <% } %>
 
       <div class="form-card">
         <div class="mb-4">


### PR DESCRIPTION
## O que foi feito

1. **Foto de perfil**
   - Pré-visualização do avatar padrão e troca dinâmica pela foto enviada pelo usuário (upload ou câmera).  
   - Captura da câmera via `navigator.mediaDevices` + `canvas.toBlob` + preenchimento automático de `<input type="file">` para o Multer.  
   - Conversão do buffer em DataURI e upload direto ao Cloudinary, preservando `fotoBase64` para edição de perfil.  
   - Ajuste no controller para buscar o registro correto de `candidato` por `usuario_id` antes de gravar no Prisma (evita P2025).

2. **Seleção de áreas de interesse**
   - Botões “pill” que podem ser marcados/desmarcados até máximo de 3 opções.  
   - JavaScript que atualiza um campo oculto (`hidden input`) com CSV das áreas selecionadas.  
   - Validação no `submit` do form para garantir exatamente 3 escolhas.  
   - Controller atualizado chamando corretamente `salvarAreasDeInteresse` no model.

3. **Fluxo de edição de perfil**
   - Mesma lógica de foto (upload + câmera) no formulário de editar perfil, preenchendo tanto `req.file` quanto `fotoBase64`.  
   - Preview instantâneo ao selecionar do dispositivo ou ao capturar pela câmera.  
   - Controller de `salvarEditarPerfil` ajustado para priorizar `req.file` e fallback em `req.body.fotoBase64`.

## Como testar

1. **Cadastro de candidato**  
   - Siga o fluxo até “Adicione uma foto de perfil”: faça upload e câmera.  
2. **Seleção de áreas**  
   - Marque 3 áreas e clique em “Continuar”; verifique na base que as 3 foram salvas.  
3. **Edição de perfil**  
   - Acesse “Meu perfil” → “Editar perfil”: altere a foto por upload e por câmera, salve e confirme no perfil que a imagem foi atualizada.

## Observações

- Os scripts JS exclusivos estão em:
  - `/js/shared/botoesFotosEditar-perfil-empresa.js`
  - `/js/candidatos/selecionar-areas.js`
- Controllers afetados:
  - `candidatoController.salvarFotoPerfil`
  - `candidatoController.salvarEditarPerfil`
  - `candidatoController.salvarAreas`