### PR TITLE
Impede cadastros incompletos de bloquearem emails no banco de dados

### DIFF
--- a/scripts/deleteUsuario.js
+++ b/scripts/deleteUsuario.js
@@ -1,72 +1,72 @@
-// deleteUsuario.js
-require('dotenv').config();
+// scripts/deleteUsuario.js
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
 async function deletarContaPorEmail(email) {
-  try {
-    const usuario = await prisma.usuario.findUnique({
-      where: { email },
-      include: { candidato: true, empresa: true },
-    });
+  email = email.trim().toLowerCase();
 
+  return prisma.$transaction(async (tx) => {
+    const usuario = await tx.usuario.findUnique({ where: { email } });
     if (!usuario) {
       console.log('Usuário não encontrado.');
       return;
     }
 
-    // Deletar candidato ou empresa relacionada
-    if (usuario.tipo === 'candidato' && usuario.candidato) {
-      await prisma.candidato_area.deleteMany({
-        where: { candidato_id: usuario.candidato.id }
-      });
+    // --- CANDIDATO ---
+    const candidato = await tx.candidato.findFirst({ where: { usuario_id: usuario.id } });
+    if (candidato) {
+      // relações do candidato
+      await tx.candidato_area.deleteMany({ where: { candidato_id: candidato.id } });
 
-      await prisma.candidato.delete({
-        where: { id: usuario.candidato.id }
-      });
+      // Se existir tabela de candidaturas, descomente uma das opções abaixo:
+      // await tx.candidatura.deleteMany({ where: { candidato_id: candidato.id } });
 
-      console.log('Candidato excluído.');
+      await tx.candidato.delete({ where: { id: candidato.id } });
+      console.log('Candidato e relações removidos.');
     }
 
-    if (usuario.tipo === 'empresa' && usuario.empresa) {
-      await prisma.vaga_soft_skill.deleteMany({
-        where: {
-          vaga: {
-            empresa_id: usuario.empresa.id
-          }
-        }
+    // --- EMPRESA ---
+    const empresa = await tx.empresa.findFirst({ where: { usuario_id: usuario.id } });
+    if (empresa) {
+      // Vagas da empresa
+      const vagas = await tx.vaga.findMany({
+        where: { empresa_id: empresa.id },
+        select: { id: true }
       });
+      const vagaIds = vagas.map(v => v.id);
 
-      await prisma.vaga_area.deleteMany({
-        where: {
-          vaga: {
-            empresa_id: usuario.empresa.id
-          }
-        }
-      });
+      if (vagaIds.length > 0) {
+        // relações das vagas
+        await tx.vaga_area.deleteMany({ where: { vaga_id: { in: vagaIds } } });
+        await tx.vaga_soft_skill.deleteMany({ where: { vaga_id: { in: vagaIds } } });
 
-      await prisma.vaga.deleteMany({
-        where: { empresa_id: usuario.empresa.id }
-      });
+        // Se existir tabela de candidaturas, descomente:
+        // await tx.candidatura.deleteMany({ where: { vaga_id: { in: vagaIds } } });
 
-      await prisma.empresa.delete({
-        where: { id: usuario.empresa.id }
-      });
+        await tx.vaga.deleteMany({ where: { id: { in: vagaIds } } });
+      }
 
-      console.log('Empresa excluída.');
+      await tx.empresa.delete({ where: { id: empresa.id } });
+      console.log('Empresa, vagas e relações removidas.');
     }
 
-    // Finalmente, excluir o usuário
-    await prisma.usuario.delete({
-      where: { email },
-    });
+    // --- Por fim: USUÁRIO ---
+    await tx.usuario.delete({ where: { id: usuario.id } });
+    console.log(`Usuário ${email} removido com sucesso.`);
+  });
+}
 
-    console.log('Usuário excluído com sucesso!');
+(async () => {
+  try {
+    const email = process.argv[2];
+    if (!email) {
+      console.error('Uso: node scripts/deleteUsuario.js email@exemplo.com');
+      process.exit(1);
+    }
+    await deletarContaPorEmail(email);
   } catch (err) {
     console.error('Erro ao excluir conta:', err);
   } finally {
     await prisma.$disconnect();
   }
-}
-
-deletarContaPorEmail('brunowaschburgers@gmail.com');
+})();

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,13 +1,15 @@
-exports.ensureEmpresa = (req, res, next) => {
+function ensureEmpresa(req, res, next) {
   if (!req.session.usuario || req.session.usuario.tipo !== 'empresa') {
     return res.redirect('/login');
   }
   next();
-};
+}
 
-exports.ensureCandidato = (req, res, next) => {
+function ensureCandidato(req, res, next) {
   if (!req.session.usuario || req.session.usuario.tipo !== 'candidato') {
     return res.redirect('/login');
   }
   next();
-};
+}
+
+module.exports = { ensureEmpresa, ensureCandidato };

--- a/src/views/partials/header-candidato-vagas.ejs
+++ b/src/views/partials/header-candidato-vagas.ejs
@@ -2,8 +2,8 @@
   <div class="container-fluid">
     <a class="navbar-brand" href="/candidato/home">
       <img src="/img/logo.png" class="logo-header" alt="Logo Connect Skills">
+      <img src="/img/titulo-connect-skills.png" alt="Logo Connect Skills" style="width: 180px; height: 20px;">
     </a>
-    <img src="/img/titulo-connect-skills.png" alt="Logo Connect Skills" style="width: 180px; height: 20px;">
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/src/views/partials/header-candidato.ejs
+++ b/src/views/partials/header-candidato.ejs
@@ -2,9 +2,8 @@
   <div class="container-fluid">
     <a class="navbar-brand" href="/candidato/home">
       <img src="/img/logo.png" class="logo-header" alt="Logo Connect Skills">
+      <img src="/img/titulo-connect-skills.png" alt="Logo Connect Skills" style="width: 180px; height: 20px;">
     </a>
-    <img src="/img/titulo-connect-skills.png" alt="Logo Connect Skills" style="width: 180px; height: 20px;">
-
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/src/views/partials/header-empresa.ejs
+++ b/src/views/partials/header-empresa.ejs
@@ -2,9 +2,8 @@
   <div class="container-fluid">
     <a class="navbar-brand" href="/empresas/home">
       <img src="/img/logo.png" class="logo-header" alt="Logo Connect Skills">
+      <img src="/img/titulo-connect-skills.png" alt="Logo Connect Skills" style="width: 180px; height: 20px;">
     </a>
-  <img src="/img/titulo-connect-skills.png" alt="Logo Connect Skills" style="width: 180px; height: 20px;">
-    
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
# Impede bloqueio de email com cadastros incompletos

Este PR implementa a funcionalidade de não bloquear emails quando são cadastrados no Connect Skills. Ou seja, se a pessoa cadastrar email e senha, mas não continuar a segunda etapa do cadastro, a conta de candidato/empresa não é cadastrada.

Isso impede que contas incompletas sejam cadastradas no banco de dados, tornando os emails inutilizáveis.

Se o usuário cadastrar email e senha, mas não finalizar o segundo cadastro como candidato/empresa, ele é redirecionado para onde parou.

## Próximos passos

Implementar model que pergunta ao usuário se ele deseja continuar o cadastro aonde ele estava ou reiniciar o cadastro.